### PR TITLE
Add NVENC support, API key auth, and configurable path exclusions

### DIFF
--- a/config.py
+++ b/config.py
@@ -4,26 +4,28 @@ import platform
 import os
 
 # 🌐 Stash API connection
-stash_host = "192.168.1.71"
+stash_scheme = "http"
+stash_host = "localhost"
 stash_port = 9999
+stash_api_key = ""  # Set your Stash API key here (Settings → Security → API Key)
 
 windows = platform.system() == "Windows"
 
 # 📁 External tool paths
 binary_windows = r".\bin\videohashes-windows.exe"
-binary_linux = r"./bin/videohashes-linux"
+binary_linux = r"./videohashes-linux-amd64"
 binary = binary_windows if windows else binary_linux
 
 ffmpeg = r"c:\mediatools\ffmpeg.exe" if windows else "/usr/bin/ffmpeg"
 ffprobe = r"c:\mediatools\ffprobe.exe" if windows else "/usr/bin/ffprobe"
 
-sprite_path = r"Y:/stash/generated/vtt" if windows else "/mnt/stash/stash/generated/vtt"
-preview_path = r"Y:/stash/generated/screenshots" if windows else "/mnt/stash/stash/generated/screenshots"
+sprite_path = r"Y:/stash/generated/vtt" if windows else "/mnt/stash/generated/vtt"
+preview_path = r"Y:/stash/generated/screenshots" if windows else "/mnt/stash/generated/screenshots"
 
 # 🏷️ Stash tag IDs
-hashing_tag = 15015
-hashing_error_tag = 15018
-cover_error_tag = 15019
+hashing_tag = 0      # Stash tag ID for "In Process" — create tag and set ID here
+hashing_error_tag = 0  # Stash tag ID for "Hashing Error"
+cover_error_tag = 0    # Stash tag ID for "Cover Error"
 
 # 🔢 Batch size for scene processing
 per_page = 25  # --batch-size: Number of scenes to process per run (default: 25)
@@ -45,6 +47,12 @@ preview_skip_seconds = 15
 dry_run = False  # --dry-run: Simulate processing without writing changes
 once = False     # --once: Run one batch then exit
 verbose = False  # --verbose: Display additional information including progress bars for generation tasks
+nvenc = True     # Use NVIDIA NVENC hardware encoder for preview video generation
+
+# 🚫 Stash paths to exclude from processing (matched with EXCLUDES filter)
+excluded_paths = [
+    # "/data/my-folder",  # Add Stash paths to exclude from processing
+]
 
 # 🔁 Path translations.  The path that Stash access is the Orig, the path on the local machine is obviously Local
 translations = (
@@ -54,7 +62,5 @@ translations = (
         {'orig': '/data3/', 'local': 'R:/'},
     ] if windows else [
         {'orig': '/data/', 'local': '/mnt/datadrive/'},
-        {'orig': '/data2/', 'local': '/mnt/datadrive2/'},
-        {'orig': '/data3/', 'local': '/mnt/datadrive3/'},
     ]
 )

--- a/helpers/preview_video_generator.py
+++ b/helpers/preview_video_generator.py
@@ -5,7 +5,7 @@ import os
 import shutil
 from tqdm import tqdm
 from concurrent.futures import ThreadPoolExecutor
-from config import verbose  # ✅ Import verbose flag
+from config import verbose, nvenc
 
 class PreviewVideoGenerator:
     def __init__(self, filename, output_path, filehash, ffmpeg='ffmpeg', ffprobe='ffprobe',
@@ -49,9 +49,9 @@ class PreviewVideoGenerator:
                 '-i', self.filename,
                 '-t', str(self.clip_length),
                 '-s', '640x360',
-                '-c:v', 'libx264',
-                '-crf', '18',
-                '-preset', 'slow',
+                '-c:v', 'h264_nvenc' if nvenc else 'libx264',
+                '-cq:v' if nvenc else '-crf', '18',
+                '-preset', 'p4' if nvenc else 'fast',
                 '-loglevel', 'quiet'
             ]
             if self.include_audio:
@@ -97,9 +97,9 @@ class PreviewVideoGenerator:
             '-f', 'concat',
             '-safe', '0',
             '-i', concat_file,
-            '-c:v', 'libx264',
-            '-crf', '18',
-            '-preset', 'slow',
+            '-c:v', 'h264_nvenc' if nvenc else 'libx264',
+            '-cq:v' if nvenc else '-crf', '18',
+            '-preset', 'p4' if nvenc else 'fast',
             '-loglevel', 'quiet'
         ]
         if self.include_audio:

--- a/helpers/scene_discovery.py
+++ b/helpers/scene_discovery.py
@@ -18,11 +18,14 @@ def discover_scenes():
     all_scenes = stash.find_scenes(
         f={
             "phash": {"value": "", "modifier": "IS_NULL"},
-            "tags": {"value": [config.hashing_tag, config.hashing_error_tag, config.cover_error_tag], "modifier": "EXCLUDES"}
+            "tags": {"value": [config.hashing_tag, config.hashing_error_tag, config.cover_error_tag], "modifier": "EXCLUDES"},
         },
         filter={"per_page": -1},  # Retrieve all matching scene IDs
-        fragment="id"
+        fragment="id files{path}"
     )
+
+    if config.excluded_paths:
+        all_scenes = [s for s in all_scenes if not any(ep in s['files'][0]['path'] for ep in config.excluded_paths)]
 
     # Step 2: Count total matching scenes
     total_count = len(all_scenes)
@@ -43,7 +46,7 @@ def discover_scenes():
     batch_scenes = stash.find_scenes(
         f={
             "phash": {"value": "", "modifier": "IS_NULL"},
-            "tags": {"value": [config.hashing_tag, config.hashing_error_tag, config.cover_error_tag], "modifier": "EXCLUDES"}
+            "tags": {"value": [config.hashing_tag, config.hashing_error_tag, config.cover_error_tag], "modifier": "EXCLUDES"},
         },
         filter={
             "sort": "created_at",           # Sort by creation date (newest first)
@@ -53,6 +56,9 @@ def discover_scenes():
         },
         fragment="id files{id path fingerprints{value type}} paths{screenshot}"
     )
+
+    if config.excluded_paths:
+        batch_scenes = [s for s in batch_scenes if not any(ep in s['files'][0]['path'] for ep in config.excluded_paths)]
 
     # Step 6: Return the batch of scenes to be processed
     return batch_scenes

--- a/helpers/stash_utils.py
+++ b/helpers/stash_utils.py
@@ -1,10 +1,10 @@
 # stash_utils.py
 
 from stashapi.stashapp import StashInterface
-from config import hashing_tag, hashing_error_tag, cover_error_tag, dry_run, stash_host, stash_port
+from config import hashing_tag, hashing_error_tag, cover_error_tag, dry_run, stash_scheme, stash_host, stash_port, stash_api_key, excluded_paths
 from datetime import datetime
 
-stash = StashInterface({"host": stash_host, "port": stash_port})
+stash = StashInterface({"scheme": stash_scheme, "host": stash_host, "port": stash_port, "apikey": stash_api_key})
 
 def log_scene_failure(scene_id, filename_pretty, step, error):
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -23,11 +23,13 @@ def get_total_scene_count():
     scenes = stash.find_scenes(
         f={
             "phash": {"value": "", "modifier": "IS_NULL"},
-            "tags": {"value": [hashing_tag, hashing_error_tag, cover_error_tag], "modifier": "EXCLUDES"}
+            "tags": {"value": [hashing_tag, hashing_error_tag, cover_error_tag], "modifier": "EXCLUDES"},
         },
         filter={"sort": "created_at", "direction": "DESC", "per_page": -1},
-        fragment="id"
+        fragment="id files{path}"
     )
+    if excluded_paths:
+        scenes = [s for s in scenes if not any(ep in s['files'][0]['path'] for ep in excluded_paths)]
     return len(scenes)
 
 def tag_scene_error(scene_id, error_tag, error_msg=None):


### PR DESCRIPTION
## Summary

- Add `stash_scheme` and `stash_api_key` to config for HTTPS and authenticated Stash connections
- Add `nvenc` flag; `preview_video_generator` uses `h264_nvenc` when enabled (falls back to `libx264` with `fast` preset)
- Add `excluded_paths` list to config; scene discovery filters matching paths in Python to support excluding folders from processing
- Update `binary_linux` default to `videohashes-linux-amd64`
- Simplify default Linux path translations to single entry